### PR TITLE
Preserve percentage, or all values, on stop.

### DIFF
--- a/chrome/content/extendedstatusbar.js
+++ b/chrome/content/extendedstatusbar.js
@@ -403,6 +403,7 @@ XULExtendedStatusbarChrome.esbListener =
 
 	initObjectValuesForBrowser : function(aBrowser)
 	{
+		if (aBrowser.esbValues) aBrowser.esbOldValues = aBrowser.esbValues;
 		aBrowser.esbValues = { images: "0/0", 
 								loaded: "0", 
 								speed: "0" + XULExtendedStatusbarChrome.esbXUL.esbstrings.GetStringFromName("esb.dot") + "00",
@@ -534,13 +535,18 @@ XULExtendedStatusbarChrome.esbListener =
 				this.initObjectValuesForBrowser(aBrowser);
 			}
 			aBrowser.esbValues.stateFlags = aStateFlags;
-			aBrowser.esbValues.percent = "100";
+			if (aStatus == Components.results.NS_OK) aBrowser.esbValues.percent = "100";
 			this.stopTimer(aBrowser);
 			
 			this.updateTime(aBrowser);
 			if(aBrowser == gBrowser.selectedBrowser)
 			{
 				XULExtendedStatusbarChrome.esbLoading = false;
+				if (aBrowser.esbOldValues)
+				{
+					aBrowser.esbValues = aBrowser.esbOldValues;
+					aBrowser.esbOldValues = null;
+				}
 				this.displayCurrentValuesForBrowser(aBrowser);
 			}
 		}
@@ -598,7 +604,7 @@ XULExtendedStatusbarChrome.esbListener =
 				speed = speed.toFixed(2);
 				speed = speed.replace(/\./, XULExtendedStatusbarChrome.esbXUL.esbstrings.GetStringFromName("esb.dot")); //Replace '.' with a symbol from the active local
 			}
-			aBrowser.esbValues.percent = percentage;
+			if (percentage != 100) aBrowser.esbValues.percent = percentage;
 			aBrowser.esbValues.images = imglcount + "/" + allimgsc;
 			aBrowser.esbValues.loaded = aCurTotalProgress;
 			aBrowser.esbValues.speed = speed;
@@ -619,7 +625,7 @@ XULExtendedStatusbarChrome.esbListener =
 									 aCurTotalProgress, aMaxTotalProgress);
 	},
 
-	onLocationChange: function (aBrowser, aWebProgress , aRequest , aLocation, aFlags)
+	onLocationChange: function (aBrowser, aWebProgress, aRequest, aLocation, aFlags)
 	{
 		if(aLocation)
 		{
@@ -636,6 +642,7 @@ XULExtendedStatusbarChrome.esbListener =
 				XULExtendedStatusbarChrome.esbXUL.esb_toolbar.hidden = false;
 				XULExtendedStatusbarChrome.esbXUL.status_bar.hidden = false;
 			}
+			aBrowser.esbOldValues = null;
 		}
 		else
 		{


### PR DESCRIPTION
Turns out keeping the percentage on stop wasn't that hard (fixing #10) - ignore 100% on progress change, only setting it on stop, provided it was successful.

I also preserve/restore all the values when you click on a link, but immediately stop, thus staying on the same page.
