### PR TITLE
Count CSS/form images (fixes #20).

### DIFF
--- a/chrome/content/extendedstatusbar.js
+++ b/chrome/content/extendedstatusbar.js
@@ -768,8 +768,15 @@ XULExtendedStatusbarChrome.esbListener =
 				}
 			}
 		}
-		aBrowser.esbValues.images = (allimgsc == 0) ? allimgsc : imglcount + "/" + allimgsc;
-		if (otherimgsc != 0) aBrowser.esbValues.images += "/" + (allimgsc + otherimgsc);
+		if (allimgsc == 0)
+		{
+			aBrowser.esbValues.images = otherimgsc;
+		}
+		else
+		{
+			aBrowser.esbValues.images = imglcount + "/" + allimgsc;
+			if (otherimgsc != 0) aBrowser.esbValues.images += "/" + (allimgsc + otherimgsc);
+		}
 	},
 
 	updateTime: function (aBrowser)

--- a/chrome/content/extendedstatusbar.js
+++ b/chrome/content/extendedstatusbar.js
@@ -768,7 +768,7 @@ XULExtendedStatusbarChrome.esbListener =
 				}
 			}
 		}
-		aBrowser.esbValues.images = imglcount + "/" + allimgsc;
+		aBrowser.esbValues.images = (allimgsc == 0) ? allimgsc : imglcount + "/" + allimgsc;
 		if (otherimgsc != 0) aBrowser.esbValues.images += "/" + (allimgsc + otherimgsc);
 	},
 

--- a/chrome/content/extendedstatusbar.js
+++ b/chrome/content/extendedstatusbar.js
@@ -755,7 +755,7 @@ XULExtendedStatusbarChrome.esbListener =
 			}
 			for (var i = 0; i < aBrowser.contentWindow.frames.length; i++)
 			{
-				otherimgsc += this.getDocumentImages(aBrowser.contentWindow.frames[i].document);
+				otherimgsc += this.countOtherImages(aBrowser.contentWindow.frames[i].document);
 				docimgs = aBrowser.contentWindow.frames[i].document.images;
 				for (var j = 0; j < docimgs.length; j++)
 				{

--- a/chrome/content/extendedstatusbar.js
+++ b/chrome/content/extendedstatusbar.js
@@ -576,10 +576,7 @@ XULExtendedStatusbarChrome.esbListener =
 				{
 					aBrowser.esbValues = aBrowser.esbOldValues;
 					aBrowser.esbOldValues = null;
-					for (var i in aBrowser.esbValues.imageSet)
-					{
-						aBrowser.esbValues.imageSet[i] = false;
-					}
+					aBrowser.esbValues.imageSet = null;
 				}
 				this.displayCurrentValuesForBrowser(aBrowser);
 			}
@@ -681,7 +678,7 @@ XULExtendedStatusbarChrome.esbListener =
 					image.onload = function ()
 					{
 						// Don't count again if the old values were restored.
-						if (this.esbBrowser.esbValues.imageSet[this.src])
+						if (this.esbBrowser.esbValues.imageSet)
 						{
 							++this.esbBrowser.esbValues.imagesLoaded;
 							if (this.esbBrowser == gBrowser.selectedBrowser && !XULExtendedStatusbarChrome.esbLoading)

--- a/chrome/content/extendedstatusbar.js
+++ b/chrome/content/extendedstatusbar.js
@@ -662,7 +662,7 @@ XULExtendedStatusbarChrome.esbListener =
 	{
 		function checkImage(aSrc)
 		{
-			if (aBrowser.esbValues.imageSet[aSrc] && aBrowser.esbValues.imageSet[aSrc])
+			if (aBrowser.esbValues.imageSet && aBrowser.esbValues.imageSet[aSrc])
 			{
 				aBrowser.esbValues.imageSet[aSrc] = true;
 				++aBrowser.esbValues.imagesTotal;

--- a/chrome/content/extendedstatusbar.js
+++ b/chrome/content/extendedstatusbar.js
@@ -662,7 +662,7 @@ XULExtendedStatusbarChrome.esbListener =
 	{
 		function checkImage(aSrc)
 		{
-			if (!aBrowser.esbValues.imageSet[aSrc])
+			if (aBrowser.esbValues.imageSet[aSrc] && aBrowser.esbValues.imageSet[aSrc])
 			{
 				aBrowser.esbValues.imageSet[aSrc] = true;
 				++aBrowser.esbValues.imagesTotal;

--- a/chrome/content/extendedstatusbar.js
+++ b/chrome/content/extendedstatusbar.js
@@ -662,7 +662,7 @@ XULExtendedStatusbarChrome.esbListener =
 	{
 		function checkImage(aSrc)
 		{
-			if (aBrowser.esbValues.imageSet && aBrowser.esbValues.imageSet[aSrc])
+			if (aBrowser.esbValues.imageSet && !aBrowser.esbValues.imageSet[aSrc])
 			{
 				aBrowser.esbValues.imageSet[aSrc] = true;
 				++aBrowser.esbValues.imagesTotal;

--- a/chrome/content/extendedstatusbar.js
+++ b/chrome/content/extendedstatusbar.js
@@ -768,7 +768,8 @@ XULExtendedStatusbarChrome.esbListener =
 				}
 			}
 		}
-		aBrowser.esbValues.images = imglcount + "/" + allimgsc + "/" + (allimgsc + otherimgsc);
+		aBrowser.esbValues.images = imglcount + "/" + allimgsc;
+		if (otherimgsc != 0) aBrowser.esbValues.images += "/" + (allimgsc + otherimgsc);
 	},
 
 	updateTime: function (aBrowser)

--- a/chrome/content/extendedstatusbar.js
+++ b/chrome/content/extendedstatusbar.js
@@ -576,6 +576,10 @@ XULExtendedStatusbarChrome.esbListener =
 				{
 					aBrowser.esbValues = aBrowser.esbOldValues;
 					aBrowser.esbOldValues = null;
+					for (var i in aBrowser.esbValues.imageSet)
+					{
+						aBrowser.esbValues.imageSet[i] = false;
+					}
 				}
 				this.displayCurrentValuesForBrowser(aBrowser);
 			}
@@ -676,10 +680,14 @@ XULExtendedStatusbarChrome.esbListener =
 					image.esbBrowser = aBrowser;
 					image.onload = function ()
 					{
-						++this.esbBrowser.esbValues.imagesLoaded;
-						if (this.esbBrowser == gBrowser.selectedBrowser && !XULExtendedStatusbarChrome.esbLoading)
+						// Don't count again if the old values were restored.
+						if (this.esbBrowser.esbValues.imageSet[this.src])
 						{
-							XULExtendedStatusbarChrome.esbListener.displayCurrentValuesForBrowser(this.esbBrowser);
+							++this.esbBrowser.esbValues.imagesLoaded;
+							if (this.esbBrowser == gBrowser.selectedBrowser && !XULExtendedStatusbarChrome.esbLoading)
+							{
+								XULExtendedStatusbarChrome.esbListener.displayCurrentValuesForBrowser(this.esbBrowser);
+							}
 						}
 					};
 				}


### PR DESCRIPTION
`<img>` tags are still counted as usual (although now `src`-less ones are ignored), with a new function to count CSS images, as well as `type=image` forms; `link` icons are not counted. Since apparently there's no way to know if these images are complete or not, I've just added a third value if necessary - _complete_/_total_/_all_ where _complete_ & _total_ represent the number of unique (according to `src`) `<img>` tags and _all_ is the number of all images. For example, this page shows as `3/3/4`. If there are no `<img>` tags, I've just reduced it to `0`, rather than having `0/0`.
