### PR TITLE
Fix hiding on new blank tab.

### DIFF
--- a/chrome/content/extendedstatusbar.js
+++ b/chrome/content/extendedstatusbar.js
@@ -407,8 +407,7 @@ XULExtendedStatusbarChrome.esbListener =
 		if (!aEvent.target.linkedBrowser.esbValues)
 		{
 			XULExtendedStatusbarChrome.esbXUL.esb_toolbar.hidden = true;
-			//it's happening in customizing mode
-			//XULExtendedStatusbarChrome.esbXUL.status_bar.hidden = true;
+			XULExtendedStatusbarChrome.esbXUL.status_bar.hidden = true;
 		}
 		else if (XULExtendedStatusbarChrome.hideForSites &&
 				 aEvent.target.linkedBrowser.contentDocument.location.href.match(XULExtendedStatusbarChrome.hideForSites))


### PR DESCRIPTION
When I create a new blank tab (Ctrl+T), the previous tab's stats would remain.
