### PR TITLE
Retain customized placement of Extended Statusbar after restart in non-Australis interface

### DIFF
--- a/chrome/content/esbpref.js
+++ b/chrome/content/esbpref.js
@@ -29,3 +29,5 @@ pref("extensions.extendedstatusbar.timestyle", "");
 pref("extensions.extendedstatusbar.progressstyle", "");
 pref("extensions.extendedstatusbar.cursorstyle", "");
 pref("extensions.extendedstatusbar.cursorbackgroundstyle", "");
+pref("extensions.extendedstatusbar.toolbarid", "addon-bar");
+pref("extensions.extendedstatusbar.nextitemid", "");


### PR DESCRIPTION
Properly save and restore position after restart in non-Australis browsers, in particular in Pale Moon.